### PR TITLE
code optimizations ( Please Review , Don't Merge)

### DIFF
--- a/batching-gson/src/test/java/com/flipkart/batching/gson/Utils.java
+++ b/batching-gson/src/test/java/com/flipkart/batching/gson/Utils.java
@@ -52,12 +52,10 @@ public class Utils {
      * @param size
      * @return dataList
      */
-    private static Data eventData;
-
     public static ArrayList<Data> fakeCollection(int size) {
         ArrayList<Data> dataList = new ArrayList<>();
         for (int i = 0; i < size; i++) {
-            eventData = new EventData();
+            Data eventData = new EventData();
             eventData.setEventId(System.currentTimeMillis() + System.nanoTime() + i);
             dataList.add(eventData);
         }
@@ -71,10 +69,6 @@ public class Utils {
         public CustomTagData(Tag tag, JSONObject event) {
             super(tag);
             this.event = event;
-        }
-
-        public JSONObject getEvent() {
-            return event;
         }
 
         @Override

--- a/batching/src/main/java/com/flipkart/batching/BatchManager.java
+++ b/batching/src/main/java/com/flipkart/batching/BatchManager.java
@@ -34,8 +34,6 @@ import com.flipkart.batching.core.SerializationStrategy;
 import com.flipkart.batching.toolbox.LogUtil;
 
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * BatchManager that implements {@link BatchController} interface. BatchManager uses builder pattern
@@ -202,5 +200,6 @@ public class BatchManager<E extends Data, T extends Batch<E>> implements BatchCo
         public BatchManager<E, T> build(Context context) {
             return new BatchManager<>(this, context);
         }
+
     }
 }

--- a/batching/src/main/java/com/flipkart/batching/TagBatchManager.java
+++ b/batching/src/main/java/com/flipkart/batching/TagBatchManager.java
@@ -39,8 +39,6 @@ import com.flipkart.batching.strategy.TagBatchingStrategy;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.Set;
 
 /**
  * TagBatchManager class that extends {@link BatchController}.
@@ -53,13 +51,12 @@ public class TagBatchManager<E extends Data, T extends Batch<E>> implements Batc
     SerializationStrategy<E, T> serializationStrategy;
     TagBatchingStrategy<TagData> tagBatchingStrategy;
     TagBatchReadyListener<TagData> tagBatchReadyListener;
-    private ArrayList<TagInfo> tagParametersList = new ArrayList<>();
 
     protected TagBatchManager(Builder builder, final Context context) {
         tagBatchingStrategy = new TagBatchingStrategy<>();
         tagBatchReadyListener = new TagBatchReadyListener<>();
 
-        tagParametersList = builder.getTagInfoList();
+        ArrayList<TagInfo> tagParametersList = builder.getTagInfoList();
 
         for (int i = 0; i < tagParametersList.size(); i++) {
             tagBatchReadyListener.addListenerForTag(tagParametersList.get(i).tag, tagParametersList.get(i).tagBatchReadyListener);

--- a/batching/src/main/java/com/flipkart/batching/listener/NetworkPersistedBatchReadyListener.java
+++ b/batching/src/main/java/com/flipkart/batching/listener/NetworkPersistedBatchReadyListener.java
@@ -166,7 +166,7 @@ public class NetworkPersistedBatchReadyListener<E extends Data, T extends Batch<
                         public void run() {
                             waitingForCallback = false;
                             LogUtil.log(TAG, "callback received for {}" + this);
-                            if (!value.complete || (value.httpErrorCode >= HTTP_SERVER_ERROR_CODE_RANGE_START) && value.httpErrorCode <= HTTP_SERVER_ERROR_CODE_RANGE_END) {
+                            if (!value.complete || (value.httpErrorCode >= HTTP_SERVER_ERROR_CODE_RANGE_START && value.httpErrorCode <= HTTP_SERVER_ERROR_CODE_RANGE_END)) {
                                 retryCount++;
                                 if (retryCount < maxRetryCount) {
                                     int backOff = exponentialBackOff();

--- a/batching/src/main/java/com/flipkart/batching/listener/NetworkPersistedBatchReadyListener.java
+++ b/batching/src/main/java/com/flipkart/batching/listener/NetworkPersistedBatchReadyListener.java
@@ -218,7 +218,7 @@ public class NetworkPersistedBatchReadyListener<E extends Data, T extends Batch<
      * @return new timeOut
      */
     int exponentialBackOff() {
-        mCurrentTimeoutMs += (mCurrentTimeoutMs * defaultBackoffMultiplier);
+        mCurrentTimeoutMs = (int) (mCurrentTimeoutMs + (mCurrentTimeoutMs * defaultBackoffMultiplier));
         return mCurrentTimeoutMs;
     }
 

--- a/batching/src/main/java/com/flipkart/batching/listener/NetworkPersistedBatchReadyListener.java
+++ b/batching/src/main/java/com/flipkart/batching/listener/NetworkPersistedBatchReadyListener.java
@@ -218,7 +218,7 @@ public class NetworkPersistedBatchReadyListener<E extends Data, T extends Batch<
      * @return new timeOut
      */
     int exponentialBackOff() {
-        mCurrentTimeoutMs = (int) (mCurrentTimeoutMs + (mCurrentTimeoutMs * defaultBackoffMultiplier));
+        mCurrentTimeoutMs += (mCurrentTimeoutMs * defaultBackoffMultiplier);
         return mCurrentTimeoutMs;
     }
 

--- a/batching/src/main/java/com/flipkart/batching/listener/NetworkPersistedBatchReadyListener.java
+++ b/batching/src/main/java/com/flipkart/batching/listener/NetworkPersistedBatchReadyListener.java
@@ -54,7 +54,6 @@ public class NetworkPersistedBatchReadyListener<E extends Data, T extends Batch<
     int maxRetryCount;
     boolean needsResumeOnReady = false;
     boolean waitingForCallback = false;
-    boolean receiverRegistered;
     boolean callFinishAfterMaxRetry = false;
     private NetworkBatchListener<E, T> networkBatchListener;
     private Context context;
@@ -119,20 +118,19 @@ public class NetworkPersistedBatchReadyListener<E extends Data, T extends Batch<
     }
 
     void unregisterReceiver() {
-        if (receiverRegistered) {
+        if (null != networkBroadcastReceiver) {
             context.unregisterReceiver(networkBroadcastReceiver);
-            receiverRegistered = false;
+            networkBroadcastReceiver = null;
             LogUtil.log(TAG, "Unregistered network broadcast receiver {}" + this);
         }
     }
 
     void registerReceiverIfRequired() {
-        if (!receiverRegistered) {
+        if (null == networkBroadcastReceiver) {
             //Register the broadcast receiver
             networkBroadcastReceiver = new NetworkBroadcastReceiver();
             IntentFilter filter = new IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION);
             context.registerReceiver(networkBroadcastReceiver, filter);
-            receiverRegistered = true;
             LogUtil.log(TAG, "Registered network broadcast receiver {}" + this);
         }
     }

--- a/batching/src/main/java/com/flipkart/batching/listener/NetworkPersistedBatchReadyListener.java
+++ b/batching/src/main/java/com/flipkart/batching/listener/NetworkPersistedBatchReadyListener.java
@@ -44,7 +44,8 @@ import com.flipkart.batching.toolbox.LogUtil;
  */
 public class NetworkPersistedBatchReadyListener<E extends Data, T extends Batch<E>> extends TrimPersistedBatchReadyListener<E, T> {
     private static final String TAG = "NetworkPersistedBatchReadyListener";
-    private static final int HTTP_SERVER_ERROR_CODE_RANGE_START = 300;
+    private static final int HTTP_SERVER_ERROR_CODE_RANGE_START = 500;
+    private static final int HTTP_SERVER_ERROR_CODE_RANGE_END = 599;
     public int defaultTimeoutMs = 2500;
     public float defaultBackoffMultiplier = 1f;
     T lastBatch;
@@ -165,7 +166,7 @@ public class NetworkPersistedBatchReadyListener<E extends Data, T extends Batch<
                         public void run() {
                             waitingForCallback = false;
                             LogUtil.log(TAG, "callback received for {}" + this);
-                            if (!value.complete || (value.httpErrorCode >= HTTP_SERVER_ERROR_CODE_RANGE_START)) {
+                            if (!value.complete || (value.httpErrorCode >= HTTP_SERVER_ERROR_CODE_RANGE_START) && value.httpErrorCode <= HTTP_SERVER_ERROR_CODE_RANGE_END) {
                                 retryCount++;
                                 if (retryCount < maxRetryCount) {
                                     int backOff = exponentialBackOff();

--- a/batching/src/main/java/com/flipkart/batching/listener/PersistedBatchReadyListener.java
+++ b/batching/src/main/java/com/flipkart/batching/listener/PersistedBatchReadyListener.java
@@ -186,11 +186,12 @@ public class PersistedBatchReadyListener<E extends Data, T extends Batch<E>> imp
         handler.post(new Runnable() {
             @Override
             public void run() {
-                if (queueFile.size() > 0) {
+                int queueSize = queueFile.size();
+                if (queueSize > 0) {
                     try {
                         if (peekedBatch != null) {
                             if (batch != null && batch.equals(peekedBatch)) {
-                                boolean isCached = cachedQueue.size() == queueFile.size();
+                                boolean isCached = cachedQueue.size() == queueSize;
                                 queueFile.remove();
                                 if (isCached) {
                                     cachedQueue.remove();

--- a/batching/src/main/java/com/flipkart/batching/persistence/DatabaseHelper.java
+++ b/batching/src/main/java/com/flipkart/batching/persistence/DatabaseHelper.java
@@ -127,7 +127,7 @@ public class DatabaseHelper<E extends Data, T extends Batch> extends SQLiteOpenH
      * @param dataCollection collection of {@link Data} objects to be deleted
      */
     public void deleteDataList(Collection<E> dataCollection) {
-        List<String> eventIdList = new ArrayList<>();
+        List<String> eventIdList = new ArrayList<>(dataCollection.size());
         for (E data : dataCollection) {
             eventIdList.add(String.valueOf(data.getEventId()));
         }

--- a/batching/src/main/java/com/flipkart/batching/persistence/TagBasedPersistenceStrategy.java
+++ b/batching/src/main/java/com/flipkart/batching/persistence/TagBasedPersistenceStrategy.java
@@ -43,15 +43,12 @@ public class TagBasedPersistenceStrategy<E extends Data> implements PersistenceS
     public TagBasedPersistenceStrategy(Tag tag, PersistenceStrategy<E> persistenceStrategy) {
         if (tag == null) {
             throw new IllegalArgumentException("Tag cannot be null");
-        } else {
-            this.tag = tag;
         }
-
         if (persistenceStrategy == null) {
             throw new IllegalArgumentException("PersistenceStrategy cannot be null");
-        } else {
-            this.persistenceStrategy = persistenceStrategy;
         }
+        this.tag = tag;
+        this.persistenceStrategy = persistenceStrategy;
     }
 
     @Override

--- a/batching/src/main/java/com/flipkart/batching/tape/InMemoryObjectQueue.java
+++ b/batching/src/main/java/com/flipkart/batching/tape/InMemoryObjectQueue.java
@@ -60,10 +60,7 @@ public class InMemoryObjectQueue<T> implements ObjectQueue<T> {
     @Override
     public void remove(int n) {
         for (int i = 0; i < n; i++) {
-            tasks.remove();
-            if (listener != null) {
-                listener.onRemove(this);
-            }
+            remove();
         }
     }
 

--- a/batching/src/test/java/com/flipkart/batching/listener/NetworkPersistedBatchReadyTest.java
+++ b/batching/src/test/java/com/flipkart/batching/listener/NetworkPersistedBatchReadyTest.java
@@ -141,7 +141,7 @@ public class NetworkPersistedBatchReadyTest extends BaseTestClass {
         //verify that it gets called once
         verify(networkBatchListener, times(6)).performNetworkRequest(any(Batch.class), any(ValueCallback.class));
         //verify that it gets called 2 times
-        shadowLooper.idle(networkPersistedBatchReadyListener.getDefaultTimeoutMs());
+        shadowLooper.idle(networkPersistedBatchReadyListener.getDefaultTimeoutMs() * 2);
         verify(networkBatchListener, times(7)).performNetworkRequest(any(Batch.class), any(ValueCallback.class));
     }
 
@@ -360,14 +360,14 @@ public class NetworkPersistedBatchReadyTest extends BaseTestClass {
         shadowLooper.idle();
         // note : now flow will get resumed, which mean network request for first batch is retried (NOT second batch)
         verify(networkBatchListener, times(5)).performNetworkRequest(eq(firstBatch), any(ValueCallback.class));
-        shadowLooper.idle(callbackIdle + networkPersistedBatchReadyListener.getDefaultTimeoutMs());
+        shadowLooper.idle(callbackIdle + networkPersistedBatchReadyListener.getDefaultTimeoutMs() * 2);
         sendFakeNetworkBroadcast(context);
         verify(networkBatchListener, times(6)).performNetworkRequest(eq(firstBatch), any(ValueCallback.class));
 
         requestResponse.complete = true;
         requestResponse.httpErrorCode = 200;
         sendFakeNetworkBroadcast(context);
-        shadowLooper.idle(callbackIdle + networkPersistedBatchReadyListener.getDefaultTimeoutMs() * 2); // this will call second batch
+        shadowLooper.idle(callbackIdle + networkPersistedBatchReadyListener.getDefaultTimeoutMs() * 4); // this will call second batch
         //verify that it gets called 1 time with new batch
         verify(networkBatchListener, times(1)).performNetworkRequest(eq(secondBatch), any(ValueCallback.class));
         shadowLooper.runToEndOfTasks();

--- a/batching/src/test/java/com/flipkart/batching/listener/NetworkPersistedBatchReadyTest.java
+++ b/batching/src/test/java/com/flipkart/batching/listener/NetworkPersistedBatchReadyTest.java
@@ -109,19 +109,19 @@ public class NetworkPersistedBatchReadyTest extends BaseTestClass {
         //verify that it gets called once
         verify(networkBatchListener, times(1)).performNetworkRequest(any(Batch.class), any(ValueCallback.class));
         //verify that it gets called 2 times
-        shadowLooper.idle(networkPersistedBatchReadyListener.getDefaultTimeoutMs());
+        shadowLooper.idle(networkPersistedBatchReadyListener.getDefaultTimeoutMs() * 2);
         verify(networkBatchListener, times(2)).performNetworkRequest(any(Batch.class), any(ValueCallback.class));
         //verify that it gets called 3 times
-        shadowLooper.idle(callbackIdle + networkPersistedBatchReadyListener.getDefaultTimeoutMs() * 2);
+        shadowLooper.idle(callbackIdle + networkPersistedBatchReadyListener.getDefaultTimeoutMs() * 4);
         verify(networkBatchListener, times(3)).performNetworkRequest(any(Batch.class), any(ValueCallback.class));
         //verify that it gets called 4 times
-        shadowLooper.idle(callbackIdle + networkPersistedBatchReadyListener.getDefaultTimeoutMs() * 4);
+        shadowLooper.idle(callbackIdle + networkPersistedBatchReadyListener.getDefaultTimeoutMs() * 8);
         verify(networkBatchListener, times(4)).performNetworkRequest(any(Batch.class), any(ValueCallback.class));
         //verify that it gets called 5 times
-        shadowLooper.idle(callbackIdle + networkPersistedBatchReadyListener.getDefaultTimeoutMs() * 8);
+        shadowLooper.idle(callbackIdle + networkPersistedBatchReadyListener.getDefaultTimeoutMs() * 16);
         verify(networkBatchListener, times(5)).performNetworkRequest(any(Batch.class), any(ValueCallback.class));
         //verify that it does not gets called after 5 times
-        shadowLooper.idle(callbackIdle + networkPersistedBatchReadyListener.getDefaultTimeoutMs() * 16);
+        shadowLooper.idle(callbackIdle + networkPersistedBatchReadyListener.getDefaultTimeoutMs() * 32);
 
         ArgumentCaptor<ValueCallback> valueCallbackCapture = ArgumentCaptor.forClass(ValueCallback.class);
         verify(networkBatchListener, times(5)).performNetworkRequest(any(Batch.class), valueCallbackCapture.capture());
@@ -338,18 +338,18 @@ public class NetworkPersistedBatchReadyTest extends BaseTestClass {
 
         //verify that it gets called 1 times
         verify(networkBatchListener, times(1)).performNetworkRequest(eq(firstBatch), any(ValueCallback.class));
-        shadowLooper.idle(networkPersistedBatchReadyListener.getDefaultTimeoutMs());
+        shadowLooper.idle(networkPersistedBatchReadyListener.getDefaultTimeoutMs() * 2);
         //verify that it gets called 2 times after waiting for specified time
         verify(networkBatchListener, times(2)).performNetworkRequest(eq(firstBatch), any(ValueCallback.class));
-        shadowLooper.idle(callbackIdle + networkPersistedBatchReadyListener.getDefaultTimeoutMs() * 2);
+        shadowLooper.idle(callbackIdle + networkPersistedBatchReadyListener.getDefaultTimeoutMs() * 4);
         //verify that it gets called 3 times after waiting for specified time
         verify(networkBatchListener, times(3)).performNetworkRequest(eq(firstBatch), any(ValueCallback.class));
         //verify that it gets called 3 times after waiting for specified time
-        shadowLooper.idle(callbackIdle + networkPersistedBatchReadyListener.getDefaultTimeoutMs() * 4);
+        shadowLooper.idle(callbackIdle + networkPersistedBatchReadyListener.getDefaultTimeoutMs() * 8);
         //verify that it gets called 4 times after waiting for specified time
         verify(networkBatchListener, times(4)).performNetworkRequest(eq(firstBatch), any(ValueCallback.class));
         sendFakeNetworkBroadcast(context);
-        shadowLooper.idle(callbackIdle + networkPersistedBatchReadyListener.getDefaultTimeoutMs() * 8);
+        shadowLooper.idle(callbackIdle + networkPersistedBatchReadyListener.getDefaultTimeoutMs() * 16);
         // now it should have stopped retrying anymore since max retry is reached
         verify(networkBatchListener, times(4)).performNetworkRequest(eq(firstBatch), any(ValueCallback.class));
 
@@ -401,17 +401,17 @@ public class NetworkPersistedBatchReadyTest extends BaseTestClass {
 
         //verify that it gets called 1 times
         verify(networkBatchListener, times(1)).performNetworkRequest(eq(firstBatch), any(ValueCallback.class));
-        shadowLooper.idle(networkPersistedBatchReadyListener.getDefaultTimeoutMs());
+        shadowLooper.idle(networkPersistedBatchReadyListener.getDefaultTimeoutMs() * 2);
         //verify that it gets called 2 times after waiting for specified time
         verify(networkBatchListener, times(2)).performNetworkRequest(eq(firstBatch), any(ValueCallback.class));
-        shadowLooper.idle(callbackIdle + networkPersistedBatchReadyListener.getDefaultTimeoutMs() * 2);
+        shadowLooper.idle(callbackIdle + networkPersistedBatchReadyListener.getDefaultTimeoutMs() * 4);
         //verify that it gets called 3 times after waiting for specified time
         verify(networkBatchListener, times(3)).performNetworkRequest(eq(firstBatch), any(ValueCallback.class));
         //verify that it gets called 3 times after waiting for specified time
-        shadowLooper.idle(callbackIdle + networkPersistedBatchReadyListener.getDefaultTimeoutMs() * 4);
+        shadowLooper.idle(callbackIdle + networkPersistedBatchReadyListener.getDefaultTimeoutMs() * 8);
         //verify that it gets called 4 times after waiting for specified time
         verify(networkBatchListener, times(4)).performNetworkRequest(eq(firstBatch), any(ValueCallback.class));
-        shadowLooper.idle(callbackIdle + networkPersistedBatchReadyListener.getDefaultTimeoutMs() * 8);
+        shadowLooper.idle(callbackIdle + networkPersistedBatchReadyListener.getDefaultTimeoutMs() * 16);
         // now it should have stopped retrying anymore since max retry is reached
         verify(networkBatchListener, times(4)).performNetworkRequest(eq(firstBatch), any(ValueCallback.class));
 


### PR DESCRIPTION
Changes -:
Initialising variable only when needed.
Corrected retry exponential logic so in present case if it fails then it again try with the same timeout rather than the exponential one , so in present case it will be like if 3 time retry happening then retry time is 1,2,4 rather than 2,4,8 , as first failure anyhow has timeout default of 1. Volley is alsi using the same https://github.com/google/volley/blob/master/src/main/java/com/android/volley/DefaultRetryPolicy.java

 /**
     * Prepares for the next retry by applying a backoff to the timeout.
     * @param error The error code of the last attempt.
     */
    @Override
    public void retry(VolleyError error) throws VolleyError {
        mCurrentRetryCount++;
        mCurrentTimeoutMs += (mCurrentTimeoutMs * mBackoffMultiplier);
        if (!hasAttemptRemaining()) {
            throw error;
        }
    }

If array is getting initialize then initialize with correct size.

