### PR TITLE
Handling outOfBounds exception in QueueFile readElement

### DIFF
--- a/batching/src/main/java/com/flipkart/batching/tape/QueueFile.java
+++ b/batching/src/main/java/com/flipkart/batching/tape/QueueFile.java
@@ -179,16 +179,22 @@ public class QueueFile implements Closeable {
         raf.seek(0);
         raf.readFully(buffer);
         fileLength = readInt(buffer, 0);
+        elementCount = readInt(buffer, 4);
+        int firstOffset = readInt(buffer, 8);
+        int lastOffset = readInt(buffer, 12);
         if (fileLength > raf.length()) {
             throw new IOException(
                     "File is truncated. Expected length: " + fileLength + ", Actual length: " + raf.length());
         } else if (fileLength <= 0) {
             throw new IOException(
                     "File is corrupt; length stored in header (" + fileLength + ") is invalid.");
+        } else if (firstOffset < 0 || fileLength <= wrapPosition(firstOffset)) {
+            throw new IOException(
+                    "File is corrupt; first position stored in header (" + firstOffset + ") is invalid.");
+        } else if (lastOffset < 0 || fileLength <= wrapPosition(lastOffset)) {
+            throw new IOException(
+                    "File is corrupt; last position stored in header (" + lastOffset + ") is invalid.");
         }
-        elementCount = readInt(buffer, 4);
-        int firstOffset = readInt(buffer, 8);
-        int lastOffset = readInt(buffer, 12);
         first = readElement(firstOffset);
         last = readElement(lastOffset);
     }


### PR DESCRIPTION
#### Issue Reference
Corrupt files in Android 9+ cause a crash in Tape library's `QueueFile`. This is explained well in segmentio's `analytics-android`'s issues [here](https://github.com/segmentio/analytics-android/issues/586#issuecomment-594331218), and subsequently handled in this [PR](https://github.com/segmentio/analytics-android/pull/646/files).

Adding the same change here. To summarise, this should help with handling invalid `firstOffset` and `lastOffset` values in the header.

Any fix for this directly in the Tape library could't be found. There's a commit [here](https://github.com/square/tape/commit/e98421ed3a8fa57324117654367b3f66845c1d60#diff-721a5d12616222e57f588f503286c0250c6bdc9380f1856e70f8f6ffa8748d4dR158), which changes the invalid header condition but it seems to be part of a larger change.


