### PR TITLE
Exposing forced argument from BatchController

### DIFF
--- a/batching-core/build.gradle
+++ b/batching-core/build.gradle
@@ -14,7 +14,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 28
         versionCode 1
-        versionName "1.3.11"
+        versionName "1.3.12"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/batching-gson/build.gradle
+++ b/batching-gson/build.gradle
@@ -32,7 +32,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 28
         versionCode 1
-        versionName "1.3.11"
+        versionName "1.3.12"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/batching/build.gradle
+++ b/batching/build.gradle
@@ -38,7 +38,7 @@ android {
         minSdkVersion 14
         targetSdkVersion 28
         versionCode 1
-        versionName "1.3.11"
+        versionName "1.3.12"
     }
 
     buildTypes {

--- a/batching/src/main/java/com/flipkart/batching/BatchController.java
+++ b/batching/src/main/java/com/flipkart/batching/BatchController.java
@@ -44,8 +44,16 @@ public interface BatchController<E extends Data, T extends Batch<E>> {
      *
      * @param dataCollection collection of {@link Data}
      */
-
     void addToBatch(Collection<E> dataCollection);
+
+    /**
+     * This method takes {@link Data} type {@link Collection} and a boolean as parameter and notifies the provided
+     * {@link BatchingStrategy} about the added data.
+     *
+     * @param dataCollection collection of {@link Data}
+     * @param forced whether to forcefully trigger the event call
+     */
+    void addToBatch(Collection<E> dataCollection, boolean forced);
 
     /**
      * This method returns the initialized {@link Handler}.

--- a/batching/src/main/java/com/flipkart/batching/BatchManager.java
+++ b/batching/src/main/java/com/flipkart/batching/BatchManager.java
@@ -80,13 +80,18 @@ public class BatchManager<E extends Data, T extends Batch<E>> implements BatchCo
 
     @Override
     public void addToBatch(final Collection<E> dataCollection) {
+        addToBatch(dataCollection, false);
+    }
+
+    @Override
+    public void addToBatch(final Collection<E> dataCollection, final boolean forced) {
         handler.post(new Runnable() {
             @Override
             public void run() {
                 assignEventIds(dataCollection);
                 if (batchingStrategy.isInitialized()) {
                     batchingStrategy.onDataPushed(dataCollection);
-                    batchingStrategy.flush(false);
+                    batchingStrategy.flush(forced);
                 } else {
                     throw new IllegalAccessError("BatchingStrategy is not initialized");
                 }

--- a/batching/src/main/java/com/flipkart/batching/TagBatchManager.java
+++ b/batching/src/main/java/com/flipkart/batching/TagBatchManager.java
@@ -87,13 +87,18 @@ public class TagBatchManager<E extends Data, T extends Batch<E>> implements Batc
 
     @Override
     public void addToBatch(final Collection<E> dataCollection) {
+        addToBatch(dataCollection, false);
+    }
+
+    @Override
+    public void addToBatch(final Collection<E> dataCollection, final boolean forced) {
         handler.post(new Runnable() {
             @Override
             public void run() {
                 assignEventIds(dataCollection);
                 if (tagBatchingStrategy.isInitialized()) {
                     tagBatchingStrategy.onDataPushed((Collection<TagData>) dataCollection);
-                    tagBatchingStrategy.flush(false);
+                    tagBatchingStrategy.flush(forced);
                 } else {
                     throw new IllegalAccessError("BatchingStrategy is not initialized");
                 }


### PR DESCRIPTION
#### Issue Reference
https://github.com/flipkart-incubator/batchman/issues/155

#### Change Summary
Exposing `forced` from BatchController.addToBatch so that it is configurable from callers.

#### Implementation Summary
Added a new `addToBatch` method with `forced` argument.
The previous `addToBatch` overload will now call this method with `forced` as `false` to provide a default implementation
